### PR TITLE
fix: 프리즈마 스키마 250520 오후2:30분 회의사항 적용

### DIFF
--- a/src/prisma/migrations/20250520052703_250520/migration.sql
+++ b/src/prisma/migrations/20250520052703_250520/migration.sql
@@ -1,0 +1,88 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `adminMessage` on the `Challenge` table. All the data in the column will be lost.
+  - You are about to drop the column `adminStatus` on the `Challenge` table. All the data in the column will be lost.
+  - You are about to drop the column `authorId` on the `Notification` table. All the data in the column will be lost.
+  - You are about to drop the `maxParticipant` table. If the table is not empty, all the data it contains will be lost.
+  - Added the required column `maxParticipant` to the `Challenge` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `userId` to the `Notification` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- CreateEnum
+CREATE TYPE "adminStatus" AS ENUM ('PENDING', 'ACCEPTED', 'REJECTED', 'DELETED');
+
+-- DropForeignKey
+ALTER TABLE "Notification" DROP CONSTRAINT "Notification_authorId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "maxParticipant" DROP CONSTRAINT "maxParticipant_challengeId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "maxParticipant" DROP CONSTRAINT "maxParticipant_userId_fkey";
+
+-- AlterTable
+ALTER TABLE "Challenge" DROP COLUMN "adminMessage",
+DROP COLUMN "adminStatus",
+ADD COLUMN     "maxParticipant" INTEGER NOT NULL,
+ALTER COLUMN "description" SET DEFAULT '';
+
+-- AlterTable
+ALTER TABLE "Feedback" ALTER COLUMN "content" SET DEFAULT '';
+
+-- AlterTable
+ALTER TABLE "Notification" DROP COLUMN "authorId",
+ADD COLUMN     "userId" TEXT NOT NULL,
+ALTER COLUMN "message" SET DEFAULT '';
+
+-- AlterTable
+ALTER TABLE "Work" ALTER COLUMN "content" SET DEFAULT '';
+
+-- DropTable
+DROP TABLE "maxParticipant";
+
+-- DropEnum
+DROP TYPE "AdminStatus";
+
+-- CreateTable
+CREATE TABLE "Application" (
+    "id" SERIAL NOT NULL,
+    "authorId" TEXT NOT NULL,
+    "challengeId" INTEGER NOT NULL,
+    "adminStatus" "adminStatus" NOT NULL DEFAULT 'PENDING',
+    "adminMessage" TEXT,
+    "invalidatedAt" TIMESTAMP(3),
+    "appliedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Application_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Participant" (
+    "id" SERIAL NOT NULL,
+    "challengeId" INTEGER NOT NULL,
+    "userId" TEXT NOT NULL,
+
+    CONSTRAINT "Participant_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Application_challengeId_key" ON "Application"("challengeId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Participant_userId_challengeId_key" ON "Participant"("userId", "challengeId");
+
+-- AddForeignKey
+ALTER TABLE "Application" ADD CONSTRAINT "Application_authorId_fkey" FOREIGN KEY ("authorId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Application" ADD CONSTRAINT "Application_challengeId_fkey" FOREIGN KEY ("challengeId") REFERENCES "Challenge"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Notification" ADD CONSTRAINT "Notification_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Participant" ADD CONSTRAINT "Participant_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Participant" ADD CONSTRAINT "Participant_challengeId_fkey" FOREIGN KEY ("challengeId") REFERENCES "Challenge"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/src/prisma/schema.prisma
+++ b/src/prisma/schema.prisma
@@ -12,46 +12,60 @@ model User {
   email          String   @unique
   nickname       String
   hashedPassword String?
+  refreshToken   String?
   providerId     Int?     @unique
   provider       String   @default("local")
-  refreshToken   String?
   createdAt      DateTime @default(now())
   updatedAt      DateTime @updatedAt
   role           Role     @default(USER)
   grade          Grade    @default(NORMAL)
 
-  works           Work[]
-  challenges      Challenge[]
-  notifications   Notification[]
-  likes           Like[]
-  feedbacks       Feedback[]
-  maxParticipants maxParticipant[]
+  works         Work[]
+  challenges    Challenge[]
+  notifications Notification[]
+  likes         Like[]
+  feedbacks     Feedback[]
+  participants  Participant[]
+  applications  Application[]
+}
+
+model Application {
+  id            Int         @id @default(autoincrement())
+  authorId      String
+  challengeId   Int         @unique
+  adminStatus   adminStatus @default(PENDING)
+  adminMessage  String?
+  invalidatedAt DateTime?
+  appliedAt     DateTime
+
+  user      User      @relation(fields: [authorId], references: [id])
+  challenge Challenge @relation(fields: [challengeId], references: [id])
 }
 
 model Challenge {
-  id           Int         @id @default(autoincrement())
-  authorId     String
-  title        String
-  description  String
-  category     String
-  docType      String
-  originalUrl  String
-  adminStatus  AdminStatus @default(PENDING)
-  adminMessage String?
-  deadline     DateTime
-  createdAt    DateTime    @default(now())
-  updatedAt    DateTime    @updatedAt
+  id             Int      @id @default(autoincrement())
+  authorId       String
+  title          String
+  description    String   @default("")
+  category       String
+  docType        String
+  originalUrl    String
+  deadline       DateTime
+  maxParticipant Int
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
 
-  works           Work[]
-  maxParticipants maxParticipant[]
-  user            User             @relation(fields: [authorId], references: [id], onDelete: Cascade)
+  user         User          @relation(fields: [authorId], references: [id], onDelete: Cascade)
+  application  Application?
+  works        Work[]
+  participants Participant[]
 }
 
 model Work {
   id          Int        @id @default(autoincrement())
   authorId    String
   challengeId Int
-  content     String
+  content     String     @default("")
   createdAt   DateTime   @default(now())
   updatedAt   DateTime   @updatedAt
   feedbacks   Feedback[]
@@ -65,7 +79,7 @@ model Feedback {
   id        Int      @id @default(autoincrement())
   workId    Int
   authorId  String
-  content   String
+  content   String   @default("")
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
@@ -75,13 +89,13 @@ model Feedback {
 
 model Notification {
   id        Int      @id @default(autoincrement())
-  authorId  String
+  userId    String
   isRead    Boolean  @default(false)
-  message   String
+  message   String   @default("")
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
-  user User @relation(fields: [authorId], references: [id], onDelete: Cascade)
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 }
 
 model Like {
@@ -95,10 +109,10 @@ model Like {
   @@unique([userId, workId])
 }
 
-model maxParticipant {
+model Participant {
   id          Int    @id @default(autoincrement())
-  userId      String
   challengeId Int
+  userId      String
 
   user      User      @relation(fields: [userId], references: [id], onDelete: Cascade)
   challenge Challenge @relation(fields: [challengeId], references: [id], onDelete: Cascade)
@@ -116,7 +130,7 @@ enum Role {
   ADMIN
 }
 
-enum AdminStatus {
+enum adminStatus {
   PENDING
   ACCEPTED
   REJECTED


### PR DESCRIPTION
프리즈마 스키마 250520 오후2:30분까지의 DB관련 회의사항 적용했습니다.

![image](https://github.com/user-attachments/assets/935f0057-ea60-485c-9be6-6a4f913f6ce5)

- 주 변경사항으로 `Application` 모델의 추가가 있습니다.
- Application <-> Challenge 모델의 1:1 관계 추가
- 필드명 수정 등 여러 변경사항 적용했습니다.