### PR TITLE
fix:user api 코드 수정

### DIFF
--- a/http/user.http
+++ b/http/user.http
@@ -1,22 +1,21 @@
-@access_token = accessToken=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOiJjbWF3OTNiZnIwMDAwYWhmd3dzYmJsMDB0IiwiZW1haWwiOiJ1c2VyM0B0ZXN0LmNvbSIsIm5pY2tuYW1lIjoidXNlcjMiLCJpYXQiOjE3NDc3Mjk2MzksImV4cCI6MTc0NzczMzIzOX0.kD-1ZD59OXX3b_9DEp_7qqfiYvKaBNWVEjTK12l-wlw
+@accessToken = accessToken=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOiJjbWIwYWlzeXAwMDAwY2NveWFhem1tbzllIiwiZW1haWwiOiJna3NrdGwxMjNAbmF2ZXIuY29tIiwibmlja25hbWUiOiLrgpjripTslbzrqYvsp4TquIjrtpXslrQiLCJpYXQiOjE3NDc5ODQ2NjcsImV4cCI6MTc0Nzk4ODI2N30.0P6SJtBmp1Av0GWj2hoVEd-DyNgvFUDSZnIfGMyBYqc;
 
 ### 유저 정보 조회
-
 GET http://localhost:8080/users/me
-Cookie: accessToken=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOiJjbWF3OTNiZnIwMDAwYWhmd3dzYmJsMDB0IiwiZW1haWwiOiJ1c2VyM0B0ZXN0LmNvbSIsIm5pY2tuYW1lIjoidXNlcjMiLCJpYXQiOjE3NDc3Mjk2MzksImV4cCI6MTc0NzczMzIzOX0.kD-1ZD59OXX3b_9DEp_7qqfiYvKaBNWVEjTK12l-wlw
+Cookie: accessToken={{accessToken}}
 
+### 나의 챌린지 목록 조회 - 참여중
+GET http://localhost:8080/users/me/challenges?myChallengeStatus=participated
+Cookie: accessToken={{accessToken}}
 
-### 나의 챌린지 목록 조회 (참여중)
-
-GET http://localhost:8080/users/me/challenges?myChallengeStatus=participated&keyword=next
-Authorization: Bearer {{access_token}}
-
-### 나의 챌린지 목록 조회 (완료한)
-
+### 나의 챌린지 목록 조회 - 완료된
 GET http://localhost:8080/users/me/challenges?myChallengeStatus=completed
-Authorization: Bearer {{access_token}}
+Cookie: accessToken={{accessToken}}
 
-### 나의 챌린지 목록 조회 (신청한)
-
+### 나의 챌린지 목록 조회 - 내가 만든 챌린지 (applied로 요청)
 GET http://localhost:8080/users/me/challenges?myChallengeStatus=applied
-Authorization: Bearer {{access_token}}
+Cookie: accessToken={{accessToken}}
+
+### 키워드 검색 예시 - next 키워드 포함 챌린지
+GET http://localhost:8080/users/me/challenges?myChallengeStatus=participated&keyword=next
+Cookie: accessToken={{accessToken}}

--- a/src/repositories/user.repository.js
+++ b/src/repositories/user.repository.js
@@ -14,53 +14,41 @@ export const findUserById = async (id) => {
   });
 };
 
-export const findPendingApplications = async (userId, keywordFilter) => {
-  return await prisma.application.findMany({
-    where: {
-      authorId: userId,
-      status: "PENDING",
-      challenge: keywordFilter,
-    },
-    include: {
-      challenge: true,
-    },
-  });
-};
-
 export const findParticipatedChallenges = async (
   userId,
-  afterDate,
+  now,
   keywordFilter
 ) => {
   return await prisma.participant.findMany({
     where: {
       userId,
       challenge: {
-        deadline: { gt: afterDate },
+        deadline: { gt: now },
         ...keywordFilter,
       },
     },
-    include: {
-      challenge: true,
-    },
+    include: { challenge: true },
   });
 };
 
-export const findCompletedChallenges = async (
-  userId,
-  beforeDate,
-  keywordFilter
-) => {
+export const findCompletedChallenges = async (userId, now, keywordFilter) => {
   return await prisma.participant.findMany({
     where: {
       userId,
       challenge: {
-        deadline: { lte: beforeDate },
+        deadline: { lte: now },
         ...keywordFilter,
       },
     },
-    include: {
-      challenge: true,
+    include: { challenge: true },
+  });
+};
+
+export const findMyCreatedChallenges = async (userId, keywordFilter) => {
+  return await prisma.challenge.findMany({
+    where: {
+      authorId: userId,
+      ...keywordFilter,
     },
   });
 };

--- a/src/routes/user.route.js
+++ b/src/routes/user.route.js
@@ -1,9 +1,11 @@
 import express from "express";
-import { getMyInfo } from "../controllers/user.controller.js";
+import { getMyInfo, getMyChallenges } from "../controllers/user.controller.js";
 import { verifyAccessToken } from "../middlewares/verifyToken.js";
 
 const router = express.Router();
 
 router.get("/me", verifyAccessToken, getMyInfo);
+
+router.get("/me/challenges", verifyAccessToken, getMyChallenges);
 
 export default router;

--- a/src/services/user.service.js
+++ b/src/services/user.service.js
@@ -12,7 +12,6 @@ export const getMyInfo = async (userId) => {
 
 export const getMyChallenges = async (userId, myChallengeStatus, keyword) => {
   const now = new Date();
-
   const keywordFilter = keyword
     ? {
         OR: [
@@ -21,14 +20,6 @@ export const getMyChallenges = async (userId, myChallengeStatus, keyword) => {
         ],
       }
     : {};
-
-  if (myChallengeStatus === "applied") {
-    const applications = await userRepository.findPendingApplications(
-      userId,
-      keywordFilter
-    );
-    return applications.map((a) => a.challenge);
-  }
 
   if (myChallengeStatus === "participated") {
     const participants = await userRepository.findParticipatedChallenges(
@@ -48,7 +39,14 @@ export const getMyChallenges = async (userId, myChallengeStatus, keyword) => {
     return participants.map((p) => p.challenge);
   }
 
-  // 잘못된 status
+  if (myChallengeStatus === "applied") {
+    const createdChallenges = await userRepository.findMyCreatedChallenges(
+      userId,
+      keywordFilter
+    );
+    return createdChallenges;
+  }
+
   const error = new Error("잘못된 챌린지 상태입니다.");
   error.status = 400;
   throw error;


### PR DESCRIPTION
## 💡 개요

- 기존 `User` API 중 `/users/me/challenges`의 챌린지 상태 분기 로직을 기획에 맞게 수정
- 서비스/레포지토리 구조 정리 및 `participant` 판단 기준을 유연하게 대응 가능하도록 리팩토링

---

## ✅ 주요 변경 사항

- `/users/me/challenges` API에서 챌린지 상태(`participated`, `completed`, `applied`) 기준 재정의
  - `participated`: `Participant` 테이블 + 마감일 기준 `deadline > now()`
  - `completed`: `Participant` 테이블 + 마감일 기준 `deadline <= now()`
  - `applied`: 내가 생성한 챌린지 목록 (기획자 의도 반영, 기존 신청 챌린지와 의미 다름)
- `user.controller.js` → 컨트롤러는 요청 처리만 담당
- `user.service.js` → 상태 분기 및 비즈니스 로직 처리
- `user.repository.js` → Prisma 쿼리만 분리하여 재사용성 강화
- `/users/me/challenges` 라우트 추가 및 통합

---

## 🧪 테스트 방법

- `.http` 파일 혹은 Postman에서 아래 조건으로 테스트
  - 참여중: `/users/me/challenges?myChallengeStatus=participated`
  - 완료됨: `/users/me/challenges?myChallengeStatus=completed`
  - 내가 만든 챌린지: `/users/me/challenges?myChallengeStatus=applied`
  - `keyword` 파라미터로 검색 필터도 테스트 가능

---

## 📝 기타 참고 사항

- `Participant` 생성 시점은 별도 API에서 처리
- 챌린지 상태 기준이 바뀌어도 본 로직에는 영향 없음 

---

## 📌 리뷰어에게 부탁

- 챌린지 상태 분기 로직의 명확성 확인
- 서비스/레포 분리 및 역할 구분이 자연스러운지 확인