### PR TITLE
modify: 챌린지 목록 조회 application 포함

### DIFF
--- a/src/controllers/auth.controller.js
+++ b/src/controllers/auth.controller.js
@@ -152,8 +152,8 @@ export function socialLogin(req, res, next) {
     });
 
     const redirectUrl = process.env.FRONTEND_URL;
-    console.log(`[socialLogin] Redirecting to: ${redirectUrl}/oauth-success`);
-    res.redirect(`${redirectUrl}/oauth-success`);
+    console.log(`[socialLogin] Redirecting to: ${redirectUrl}/challenges`);
+    res.redirect(`${redirectUrl}/challenges`);
   } catch (error) {
     console.error("[socialLogin] Error caught:", error.message, error.stack);
     next(error);

--- a/src/repositories/auth.repository.js
+++ b/src/repositories/auth.repository.js
@@ -28,7 +28,7 @@ async function findUserByEmail(email) {
 }
 
 async function findUserByNickname(nickname) {
-  return await prisma.user.findFirst({
+  return await prisma.user.findUnique({
     where: {
       nickname,
     },

--- a/src/repositories/challenge.repository.js
+++ b/src/repositories/challenge.repository.js
@@ -134,6 +134,12 @@ async function getChallenges(options) {
       take,
       include: {
         participants: true, // 관계 포함
+        application: {
+          select: {
+            adminStatus: true,
+            appliedAt: true,
+          },
+        },
       },
     }),
   ]);

--- a/src/routes/admin.route.js
+++ b/src/routes/admin.route.js
@@ -2,10 +2,19 @@ import express from "express";
 import { verifyAccessToken } from "../middlewares/verifyToken.js";
 import { softDeleteWork } from "../controllers/admin.controller.js";
 import { adminValidator } from "../middlewares/validator.js";
-import { updateApplicationStatus } from "../controllers/challenge.controller.js";
+import {
+  getChallenges,
+  updateApplicationStatus,
+} from "../controllers/challenge.controller.js";
 
 const adminRouter = express.Router({ mergeParams: true });
 
+adminRouter.get(
+  "/challenges/",
+  verifyAccessToken,
+  adminValidator,
+  getChallenges
+);
 adminRouter.patch(
   "/challenges/:challengeId",
   verifyAccessToken,

--- a/src/services/challenge.service.js
+++ b/src/services/challenge.service.js
@@ -79,7 +79,7 @@ async function updateApplicationById(challengeId, data) {
     return await challengeRepository.updateApplication(challengeId, data);
   } catch (e) {
     if (e.code === "P2025") {
-      throw new NotFoundError(ExceptionMessage.CHALLNEGE_NOT_FOUND);
+      throw new NotFoundError(ExceptionMessage.CHALLENGE_NOT_FOUND);
     }
   }
 }


### PR DESCRIPTION
## 변경 사항
### [1] 챌린지 목록 조회할 때 application의 adminStatus, appliedAt 포함되도록 수정
<img width="1155" alt="Screenshot 2025-05-25 at 3 45 53 PM" src="https://github.com/user-attachments/assets/5d804d8c-6383-4a50-b385-af8dc95642f9" />

### [2] 그외
- 구글 로그인 리디렉션 경로 수정
`${redirectUrl}/oauth-success` -> `${redirectUrl}/challenges`
- nickname 스키마 `@unique` 속성 추가로 `findUserByNickname`함수 수정
`prisma.user.findFirst` -> `prisma.user.findUnique`
- 어드민 라우터 챌린지 목록 조회 추가
- 오타수정