### PR TITLE
refactor : 작업물 생성, 삭제 기능에 트랜잭션을 적용했습니다

### DIFF
--- a/http/work.http
+++ b/http/work.http
@@ -1,4 +1,4 @@
-@accessToken=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOiJjbWIwYWlzeXAwMDAwY2NveWFhem1tbzllIiwiZW1haWwiOiJna3NrdGwxMjNAbmF2ZXIuY29tIiwibmlja25hbWUiOiLrgpjripTslbzrqYvsp4TquIjrtpXslrQiLCJpYXQiOjE3NDgyNTA4NjAsImV4cCI6MTc0ODI1NDQ2MH0.j6DDBGc059hFkYrE0KfAegNPpY8cdosVmY6IV-Vhs3U
+@accessToken=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOiJjbWIwYWlzeXAwMDAwY2NveWFhem1tbzllIiwiZW1haWwiOiJna3NrdGwxMjNAbmF2ZXIuY29tIiwibmlja25hbWUiOiLrgpjripTslbzrqYvsp4TquIjrtpXslrQiLCJpYXQiOjE3NDgzMDk4MjUsImV4cCI6MTc0ODMxMzQyNX0.GzsZfN2OceNkyvkJJugd94MGi0WmvlVjmZ3W6tNSlGE
 
 ### 현재 챌린지의 작업물 조회
 GET http://localhost:8080/challenges/15/works?page=1&pageSize5
@@ -6,7 +6,7 @@ Content-Type: application/json
 Cookie: accessToken={{accessToken}}
 
 ### 작업물 상세 조회
-GET http://localhost:8080/challenges/15/works/60
+GET http://localhost:8080/challenges/15/works/66
 Content-Type: application/json
 Cookie: accessToken={{accessToken}}
 
@@ -25,7 +25,7 @@ Cookie: accessToken={{accessToken}}
 }
 
 ### 작업물 삭제 .
-DELETE http://localhost:8080/works/56
+DELETE http://localhost:8080/works/66
 Cookie: accessToken={{accessToken}}
 
 ### 작업물 소프트삭제 (작업물 비활성화 필드 true)

--- a/src/services/work.service.js
+++ b/src/services/work.service.js
@@ -77,26 +77,7 @@ const createWork = async (challengeId, authorId) => {
     throw error;
   }
 
-  // 트랜잭션으로 작업물 생성과 참여자 추가를 동시에 처리
-  const result = await prisma.$transaction(async (tx) => {
-    // 작업물 생성
-    const work = await tx.work.create({
-      data: {
-        challengeId,
-        authorId,
-      },
-    });
-
-    // 참여자 추가
-    await tx.participant.create({
-      data: {
-        challengeId,
-        userId: authorId,
-      },
-    });
-
-    return work;
-  });
+  const result = await workRepository.createWork(challengeId, authorId);
 
   return result;
 };
@@ -132,34 +113,7 @@ const hardDeleteWork = async (workId, userId) => {
     throw error;
   }
 
-  const result = await prisma.$transaction(async (tx) => {
-    const work = await tx.work.findUnique({
-      where: { id: workId },
-    });
-
-    if (!work) {
-      const error = new Error("해당 작업을 찾을 수 없습니다.");
-      error.statusCode = 404;
-      throw error;
-    }
-
-    // 참여자 삭제 (복합 유니크 키 사용)
-    await tx.participant.delete({
-      where: {
-        userId_challengeId: {
-          userId: work.authorId,
-          challengeId: work.challengeId,
-        },
-      },
-    });
-
-    // 작업물 삭제
-    await tx.work.delete({
-      where: { id: workId },
-    });
-
-    return work;
-  });
+  const result = await workRepository.hardDeleteWork(workId);
 
   return result;
 };


### PR DESCRIPTION
## 요약
작업물(Work) **생성 / 하드 삭제** 시, 관련된 **참여자(Participant) 추가 / 삭제**가 함께 처리되도록 **트랜잭션을 적용**했습니다.  
또한 서비스 레이어의 트랜잭션 로직을 리포지토리로 이동해 책임을 정리했습니다.

## 변경 사항
- `work` 생성 시
  - `work` 생성 + `participant` 생성(챌린지 참여 처리)을 **단일 트랜잭션**으로 묶음
- `work` 하드 삭제 시
  - 삭제 대상 `work` 조회 → `participant` 삭제 → `work` 삭제를 **단일 트랜잭션**으로 묶음
  - 작업물이 없을 경우 `404` 에러 처리
- 서비스 레이어(`work.service.js`)에서 직접 트랜잭션을 수행하던 부분을 제거하고,
  - `workRepository.createWork`
  - `workRepository.hardDeleteWork`
  로 위임하도록 리팩터링

## 변경 파일
- `src/repositories/work.repository.js`
- `src/services/work.service.js`
- `http/work.http` (테스트용 요청 값 일부 갱신)

## 의도 / 기대효과
- 작업물 생성/삭제 과정에서 중간 단계 실패 시 부분 반영 없이 롤백되어 데이터 정합성을 보장합니다.
- 트랜잭션/DB 처리 로직을 repository로 모아 서비스 레이어의 역할을 단순화했습니다.

## 테스트
- `http/work.http` 기반으로 작업물 생성/조회/삭제 흐름을 확인했습니다.