### PR TITLE
test : process.env.NODE_ENV의 package.json 설정 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
   "type": "module",
   "main": "index.js",
   "scripts": {
-    "dev": "nodemon ./src/app.js",
-    "start": "node ./src/app.js"
+    "dev": "NODE_ENV=development nodemon server.js",
+    "start": "NODE_ENV=production node server.js"
   },
   "dependencies": {
     "@prisma/client": "^6.5.0",

--- a/src/controllers/auth.controller.js
+++ b/src/controllers/auth.controller.js
@@ -10,7 +10,8 @@ const getCookieOptions = (maxAgeSeconds) => ({
   secure: process.env.NODE_ENV === "production",
   path: "/",
   maxAge: maxAgeSeconds * 1000,
-  domain: undefined,
+  // 이건 기본값 쓰기
+  // domain: undefined,
 });
 
 export const signUp = async (req, res, next) => {


### PR DESCRIPTION
## 배포 환경에서의 테스트 코드 pr 입니다
- 현재 getCookieOptions에서  secure 설정에 process.env.NODE_ENV 가 현재 개발 모드를 제대로 출력하지 못하는 것으로 파악되어 package.json의 설정을 추가하였습니다 
![image](https://github.com/user-attachments/assets/dc12321d-d5b5-4ee8-8d86-3da42b627404)
![image](https://github.com/user-attachments/assets/208b9a06-b5c2-4589-8438-1772aac878ca)
