### PR TITLE
feat : 코드 최적화 및 만료시간 상수화 및 JWT 슬라이딩 세션 구성

### DIFF
--- a/src/controllers/auth.controller.js
+++ b/src/controllers/auth.controller.js
@@ -4,135 +4,118 @@ import {
   generateRefreshToken,
 } from "../utils/accessToken.utils.js";
 
+/**
+ * 시간 단위를 초(seconds) 기준으로 정의한 상수
+ *
+ * 사용 예시:
+ * - TIME.SECOND: 1초
+ * - TIME.MINUTE: 60초 (1분)
+ * - TIME.HOUR: 3600초 (1시간)
+ * - TIME.DAY: 86400초 (24시간)
+ * - TIME.WEEK: 604800초 (7일)
+ *
+ * 쿠키 만료시간 설정 시:
+ * - 1시간 설정: getCookieOptions(TIME.HOUR)
+ * - 2주 설정: getCookieOptions(2 * TIME.WEEK)
+ */
+const TIME = {
+  SECOND: 1,
+  MINUTE: 60, // 60 * SECOND
+  HOUR: 60 * 60, // 60 * MINUTE
+  DAY: 24 * 60 * 60, // 24 * HOUR
+  WEEK: 7 * 24 * 60 * 60, // 7 * DAY
+};
+
 const getCookieOptions = (maxAgeSeconds) => ({
   httpOnly: true,
   sameSite: "none",
   secure: false, // 테스트 하기 설정하면 http, https 상관없이 쿠키를 통과시킴
   path: "/",
   maxAge: maxAgeSeconds * 1000,
-  // 이건 기본값 쓰기
-  // domain: undefined,
 });
 
 export const signUp = async (req, res, next) => {
-  console.log("[signUp] Starting signUp process...");
   try {
-    console.log("[signUp] Calling authService.createUser with body:", req.body);
     const { accessToken, refreshToken, user } = await authService.createUser(
       req.body
     );
-    console.log("[signUp] User created:", user.id, "Tokens generated.");
 
-    console.log("[signUp] Attempting to set accessToken cookie.");
-    res.cookie("accessToken", accessToken, getCookieOptions(1 * 60 * 60));
+    // Access Token: 15분
+    res.cookie("accessToken", accessToken, getCookieOptions(15 * TIME.MINUTE));
 
-    console.log("[signUp] Attempting to set refreshToken cookie.");
-    res.cookie(
-      "refreshToken",
-      refreshToken,
-      getCookieOptions(14 * 24 * 60 * 60)
-    );
+    // Refresh Token: 2주
+    res.cookie("refreshToken", refreshToken, getCookieOptions(2 * TIME.WEEK));
 
-    console.log("[signUp] Sending JSON response with user data.");
     return res.json(user);
   } catch (error) {
-    console.error("[signUp] Error caught:", error.message, error.stack);
     next(error);
   }
 };
 
 export const signIn = async (req, res, next) => {
-  console.log("[signIn] Starting signIn process...");
   try {
-    console.log(
-      "[signIn] Calling authService.getByEmail with body:",
-      req.body.email
-    );
     const { accessToken, refreshToken, user } = await authService.getByEmail(
       req.body
     );
-    console.log("[signIn] User retrieved:", user.id, "Tokens generated.");
 
-    console.log("[signIn] Attempting to set accessToken cookie.");
-    res.cookie("accessToken", accessToken, getCookieOptions(1 * 60 * 60));
+    // Access Token: 15분
+    res.cookie("accessToken", accessToken, getCookieOptions(15 * TIME.MINUTE));
 
-    console.log("[signIn] Attempting to set refreshToken cookie.");
-    res.cookie(
-      "refreshToken",
-      refreshToken,
-      getCookieOptions(14 * 24 * 60 * 60)
-    );
+    // Refresh Token: 2주
+    res.cookie("refreshToken", refreshToken, getCookieOptions(2 * TIME.WEEK));
 
-    console.log("[signIn] Sending JSON response with user data.");
     return res.json(user);
   } catch (error) {
-    console.error("[signIn] Error caught:", error.message, error.stack);
     next(error);
   }
 };
 
 export const refreshToken = async (req, res, next) => {
-  console.log("[refreshToken] Starting refreshToken process...");
   try {
-    console.log("[refreshToken] Checking for refreshToken in cookies.");
     const refreshToken = req.cookies.refreshToken;
     if (!refreshToken) {
-      console.log("[refreshToken] No refreshToken found in cookies.");
       return res.status(401).json({ message: "No refresh token provided" });
     }
 
-    console.log("[refreshToken] Calling authService.refreshedToken.");
     const newAccessToken = await authService.refreshedToken(refreshToken);
-    console.log("[refreshToken] New accessToken generated.");
 
     res.set("etag", false);
     res.setHeader("Cache-Control", "no-store");
 
-    console.log("[refreshToken] Attempting to set new accessToken cookie.");
-    res.cookie("accessToken", newAccessToken, getCookieOptions(1 * 60 * 60));
-
-    console.log(
-      "[refreshToken] Sending JSON response: Access token refreshed and included in body."
+    // Access Token: 1시간
+    res.cookie(
+      "accessToken",
+      newAccessToken,
+      getCookieOptions(15 * TIME.MINUTE)
     );
+
     return res.status(200).json({
       message: "Access token refreshed",
       accessToken: newAccessToken,
     });
   } catch (error) {
-    console.error("[refreshToken] Error caught:", error.message, error.stack);
     next(error);
   }
 };
 
 export function socialLogin(req, res, next) {
-  console.log("[socialLogin] Starting socialLogin process...");
   try {
     if (!req.user) {
-      console.error(
-        "[socialLogin] req.user is not defined. Passport authentication failed."
-      );
       return res.redirect("/sign-in?error=auth_failed");
     }
-    console.log("[socialLogin] Generating accessToken for user:", req.user.id);
+
     const accessToken = generateAccessToken(req.user);
-    console.log("[socialLogin] Generating refreshToken for user:", req.user.id);
     const refreshToken = generateRefreshToken(req.user);
 
-    console.log("[socialLogin] Attempting to set accessToken cookie.");
-    res.cookie("accessToken", accessToken, getCookieOptions(1 * 60 * 60));
+    // Access Token: 15분
+    res.cookie("accessToken", accessToken, getCookieOptions(15 * TIME.MINUTE));
 
-    console.log("[socialLogin] Attempting to set refreshToken cookie.");
-    res.cookie(
-      "refreshToken",
-      refreshToken,
-      getCookieOptions(14 * 24 * 60 * 60)
-    );
+    // Refresh Token: 2주
+    res.cookie("refreshToken", refreshToken, getCookieOptions(2 * TIME.WEEK));
 
     const redirectUrl = process.env.FRONTEND_URL;
-    console.log(`[socialLogin] Redirecting to: ${redirectUrl}/challenges`);
     res.redirect(`${redirectUrl}/challenges`);
   } catch (error) {
-    console.error("[socialLogin] Error caught:", error.message, error.stack);
     next(error);
   }
 }


### PR DESCRIPTION
## 🔄 Access Token 만료 시간 변경

### 변경 사항
- Access Token의 만료 시간을 1시간에서 15분으로 단축
  - 보안성 강화를 위한 토큰 만료 시간 최적화

### 상세 변경 내역
1. 모든 인증 관련 엔드포인트에서 Access Token 만료 시간 수정:
   - `signUp`: 15분 설정
   - `signIn`: 15분 설정
   - `refreshToken`: 15분 설정
   - `socialLogin`: 15분 설정

### 코드 변경
```diff
- // Access Token: 1시간
- res.cookie("accessToken", accessToken, getCookieOptions(TIME.HOUR));
+ // Access Token: 15분
+ res.cookie("accessToken", accessToken, getCookieOptions(15 * TIME.MINUTE));
```

### 영향받는 파일
- `src/controllers/auth.controller.js`

### 테스트 필요 사항
- [ ] 로그인 후 Access Token이 정상적으로 15분 후 만료되는지 확인
- [ ] Refresh Token을 통한 Access Token 갱신이 정상 작동하는지 확인
- [ ] 소셜 로그인 시 토큰 만료 시간이 올바르게 적용되는지 확인