### PR TITLE
feat: 챌린지 신청 목록 전체 조회 구현

### DIFF
--- a/http/admin.http
+++ b/http/admin.http
@@ -1,6 +1,37 @@
-@accessToken=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOiJhZG1pbjEiLCJlbWFpbCI6ImFkbWluQGVtYWlsLmNvbSIsIm5pY2tuYW1lIjoi6rSA66as7J6QIiwiaWF0IjoxNzQ4MzM0MzYyLCJleHAiOjE3NDgzMzc5NjJ9.G6zzs-qeTZq6CXDAhgrzLOKCPHLyUNFnC_vYRDOtLWw
+@accessToken=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOiJhZG1pbjEiLCJlbWFpbCI6ImFkbWluQGVtYWlsLmNvbSIsIm5pY2tuYW1lIjoi6rSA66as7J6QIiwiaWF0IjoxNzQ4NDg1MTcxLCJleHAiOjE3NDg0ODg3NzF9.d4W7wlpZj7g1uO_FGRgHYQX8rHWI0D_9LrKMrxRGwI8
 
-################ 챌린지 ################
+### 챌린지 신청 목록 조회 - 신청시간 빠른순(기본)
+GET http://localhost:8080/admin/applications?page=1&pageSize=10
+Cookie: accessToken={{accessToken}}
+
+### 챌린지 신청 목록 조회 - 신청시간 느린순
+GET http://localhost:8080/admin/applications?page=1&pageSize=10&sort=appliedAt_asc
+Cookie: accessToken={{accessToken}}
+
+### 챌린지 신청 목록 조회 - 마감기한 빠른순
+GET http://localhost:8080/admin/applications?page=1&pageSize=10&sort=deadline_desc
+Cookie: accessToken={{accessToken}}
+
+### 챌린지 신청 목록 조회 - 마감기한 느린순
+GET http://localhost:8080/admin/applications?page=1&pageSize=10&sort=deadline_asc
+Cookie: accessToken={{accessToken}}
+
+### 챌린지 신청 목록 조회 - 승인대기
+GET http://localhost:8080/admin/applications?page=1&pageSize=10&sort=pending
+Cookie: accessToken={{accessToken}}
+
+### 챌린지 신청 목록 조회 - 신청승인
+GET http://localhost:8080/admin/applications?page=1&pageSize=10&sort=accepted
+Cookie: accessToken={{accessToken}}
+
+### 챌린지 신청 목록 조회 - 신청거절
+GET http://localhost:8080/admin/applications?page=1&pageSize=10&sort=rejected
+Cookie: accessToken={{accessToken}}
+
+### 챌린지 신청 목록 조회 - 검색
+GET http://localhost:8080/admin/applications?page=1&pageSize=10&keyword=next
+Cookie: accessToken={{accessToken}}
+
 ### 챌린지 승인
 PATCH http://localhost:8080/admin/challenges/20
 Content-Type: application/json 

--- a/src/controllers/challenge.controller.js
+++ b/src/controllers/challenge.controller.js
@@ -3,7 +3,6 @@ import challengeService from "../services/challenge.service.js";
 //챌린지 작업물 관련
 
 export const getAllChallenges = async (req, res) => {
-  const { userId } = req.body;
   try {
     const works = await challengeService.findAllChallenges();
     res.status(200).json({ data: works });
@@ -102,7 +101,6 @@ export const updateChallenge = async (req, res) => {
 
     res.status(200).json({ data: updateChallenge });
   } catch (error) {
-    
     if (error.statusCode === 403) {
       return res.status(403).json({ message: "관리자 권한이 필요합니다." });
     }
@@ -118,7 +116,6 @@ export const updateChallenge = async (req, res) => {
 // 챌린지 삭제
 export const deleteChallenge = async (req, res) => {
   try {
-
     const userId = req.user?.userId;
     const { challengeId } = req.params;
     await challengeService.deleteChallenge(Number(challengeId), userId);
@@ -156,7 +153,7 @@ export const getChallenges = async (req, res, next) => {
 export async function updateApplicationStatus(req, res, next) {
   try {
     const userRole = req.auth?.role;
-    if (!userRole === 'admin') {
+    if (!userRole === "admin") {
       return res.status(401).json({ message: "관리자만 접근할 수 있습니다. " });
     }
     const challengeId = Number(req.params.challengeId);
@@ -166,6 +163,20 @@ export async function updateApplicationStatus(req, res, next) {
       data
     );
     res.json({ result });
+  } catch (e) {
+    next(e);
+  }
+}
+
+export async function getApplications(req, res, next) {
+  try {
+    const { totalCount, data } = await challengeService.getApplications({
+      page: Number(req.query.page),
+      pageSize: Number(req.query.pageSize),
+      sort: req.query.sort,
+      keyword: req.query.keyword,
+    });
+    res.json({ totalCount, applications: data });
   } catch (e) {
     next(e);
   }

--- a/src/exceptions/ExceptionMessage.js
+++ b/src/exceptions/ExceptionMessage.js
@@ -1,21 +1,28 @@
 export const ExceptionMessage = {
-  // Not Found 에러
+  // Not Found
   CHALLNEGE_NOT_FOUND: "챌린지를 찾을 수 없습니다.",
   WORK_NOT_FOUND: "작업물을 찾을 수 없습니다.",
   FEEDBACK_NOT_FOUND: "피드백을 찾을 수 없습니다.",
   APPLICATION_NOT_FOUND: "신청한 챌린지를 찾을 수 없습니다.",
   USER_NOT_FOUND: "사용자를 찾을 수 없습니다.",
+  ACCESSTOKEN_NOT_FOUND: "accessToken을 찾을 수 없습니다.",
+  REFRESHTOKEN_NOT_FOUND: "refreshToken을 찾을 수 없습니다.",
 
-  // 로그인, 회원가입 유효성 검사 에러
+  // Not Match
   PASSWORD_NOT_MATCH: "비밀번호가 일치하지 않습니다.",
   PASSWORD_CONFIRMATION_NOT_MATCH: "비밀번호 확인이 일치하지 않습니다.",
+
+  // Already Exist
   ALREADY_EXISTED_EMAIL: "이미 사용중인 이메일입니다.",
   ALREADY_EXISTED_NICKNAME: "이미 사용중인 닉네임입니다.",
+
+  // Invalid
   INVALID_EMAIL: "잘못된 이메일입니다.",
   INVALID_INPUT: "필수 정보를 모두 입력해주세요.",
+  INVALID_ACCESS_TOKEN: "유효하지 않은 accessToken 입니다.",
+  INVALID_REFRESH_TOKEN: "유효하지 않은 refresh Token 입니다.",
 
   UNAUTHORIZED: "인증되지 않은 사용자입니다.",
   FORBIDDEN: "요청한 작업을 수행하기 위한 권한이 없습니다.",
-  INVALID_REFRESH_TOKEN: "유효하지 않은 리프레시 토큰입니다.",
   GOOGLE_LOGIN_FAILED: "구글 로그인에 실패하였습니다.",
 };

--- a/src/repositories/challenge.repository.js
+++ b/src/repositories/challenge.repository.js
@@ -1,4 +1,3 @@
-import { adminStatus } from "@prisma/client";
 import prisma from "../prisma/client.prisma.js";
 
 /**
@@ -158,10 +157,35 @@ async function getChallenges(options) {
   };
 }
 
+async function findAllApplications(options) {
+  const { skip, take, where, orderBy } = options;
+
+  const [totalCount, applications] = await Promise.all([
+    prisma.application.count({ where }),
+    prisma.application.findMany({
+      where,
+      orderBy,
+      skip,
+      take,
+      include: {
+        challenge: {
+          include: { participants: true },
+        },
+      },
+    }),
+  ]);
+
+  return {
+    totalCount,
+    data: applications,
+  };
+}
+
 export default {
   save,
   getChallenges,
   findAllChallenges,
+  findAllApplications,
   findUserRoleById,
   findChallengeById,
   updateChallenge,

--- a/src/routes/admin.route.js
+++ b/src/routes/admin.route.js
@@ -3,17 +3,17 @@ import { verifyAccessToken } from "../middlewares/verifyToken.js";
 import { softDeleteWork } from "../controllers/admin.controller.js";
 import { adminValidator } from "../middlewares/validator.js";
 import {
-  getChallenges,
+  getApplications,
   updateApplicationStatus,
 } from "../controllers/challenge.controller.js";
 
 const adminRouter = express.Router({ mergeParams: true });
 
 adminRouter.get(
-  "/challenges/",
+  "/applications",
   verifyAccessToken,
   adminValidator,
-  getChallenges
+  getApplications
 );
 adminRouter.patch(
   "/challenges/:challengeId",

--- a/src/routes/challenge.route.js
+++ b/src/routes/challenge.route.js
@@ -6,7 +6,6 @@ import {
   updateChallenge,
   deleteChallenge,
 } from "../controllers/challenge.controller.js";
-import { createWork, getWorkById } from "../controllers/work.controller.js";
 import { verifyAccessToken } from "../middlewares/verifyToken.js";
 import workRouter from "./work.route.js";
 
@@ -27,8 +26,6 @@ challengeRouter.put("/:challengeId", verifyAccessToken, updateChallenge);
 
 // 챌린지 삭제
 challengeRouter.delete("/:challengeId", verifyAccessToken, deleteChallenge);
-
-// --- Challenge에 종속된 Work 관련 라우트 ---
 
 // 챌린지 작업물 관련 라우터
 challengeRouter.use("/:challengeId/works", workRouter);


### PR DESCRIPTION
## 작업 내용
### 변경 전
- 기존 신청한 챌린지 목록: 챌린지 전체 조회 API 사용(`challenge` 기준)
- 페이지네이션, 필터링 기능만 있고 정렬 기능 x
### 변경 후
- 신청한 챌린지 전체 조회(`application` 기준)
- 기존 challenge repository/service/controller 사용
  - 라우터만 adminRouter 사용 
   경로: `/admin/applications`
---
#### `params`
- 페이지네이션(`page`, `pageSize`)
- 검색(`keyword` - title, description에 포함된)
- 정렬(sort)
  - 신청 시간 빠른순(기본): `appliedAt_desc`
  - 신청 시간 느린순: `appliedAt_asc`
  - 마감 기한 빠른순: `deadline_desc`
  - 마감 기한 느린순: `deadline_asc`
  - 승인 대기: `pending`
  - 신청 승인: `accepted`
  - 신청 거절: `rejected`
 #### `repsonse`
{ totalCount, applications: data } 형식

<img width="1382" alt="image" src="https://github.com/user-attachments/assets/96ce40a4-aa62-470c-8f25-399aa41c4f56" />
