### PR TITLE
Feat/application

### DIFF
--- a/http/user.http
+++ b/http/user.http
@@ -1,4 +1,4 @@
-@accessToken=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOiJjbWIwYWlzeXAwMDAwY2NveWFhem1tbzllIiwiZW1haWwiOiJna3NrdGwxMjNAbmF2ZXIuY29tIiwibmlja25hbWUiOiLrgpjripTslbzrqYvsp4TquIjrtpXslrQiLCJpYXQiOjE3NDgzNDc5NDIsImV4cCI6MTc0ODM1MTU0Mn0.gLpbXOfGsg9gJn4BkxnOygVyN_GmSMmXMRPeGrY_KAI
+@accessToken=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOiJjbWIwYWlzeXAwMDAwY2NveWFhem1tbzllIiwiZW1haWwiOiJna3NrdGwxMjNAbmF2ZXIuY29tIiwibmlja25hbWUiOiLrgpjripTslbzrqYvsp4TquIjrtpXslrQiLCJpYXQiOjE3NDg1Mjg2NjYsImV4cCI6MTc0ODUzMjI2Nn0.Id8XdZedOh13AkXgyhx2PG4UdG_Bxvy1xsu2iVMO7MM
 
 ### 유저 정보 조회
 GET http://localhost:8080/users/me
@@ -13,7 +13,7 @@ GET http://localhost:8080/users/me/challenges?myChallengeStatus=completed
 Cookie: accessToken={{accessToken}}
 
 ### 나의 챌린지 목록 조회 - 신청한
-GET http://localhost:8080/users/me/challenges?myChallengeStatus=applied&page=2&pageSize=5
+GET http://localhost:8080/users/me/applications?page=1&pageSize=10
 Cookie: accessToken={{accessToken}}
 
 ### 키워드 검색 예시 - next 키워드 포함 챌린지

--- a/src/controllers/challenge.controller.js
+++ b/src/controllers/challenge.controller.js
@@ -136,7 +136,6 @@ export const deleteChallenge = async (req, res) => {
 };
 
 //챌린지 목록 조회
-
 export const getChallenges = async (req, res, next) => {
   try {
     const challenges = await challengeService.getChallenges(req.query);
@@ -147,9 +146,7 @@ export const getChallenges = async (req, res, next) => {
   }
 };
 
-/**
- * 챌린지 신청 관리(승인/거절/삭제)
- */
+// 챌린지 신청 관리 (승인/거절/삭제)
 export async function updateApplicationStatus(req, res, next) {
   try {
     const userRole = req.auth?.role;
@@ -168,6 +165,7 @@ export async function updateApplicationStatus(req, res, next) {
   }
 }
 
+// 챌린지 신청 목록 조회 (어드민/유저)
 export async function getApplications(req, res, next) {
   try {
     const { userId } = req.user || {}; // 나의 챌린지일 경우
@@ -184,3 +182,20 @@ export async function getApplications(req, res, next) {
     next(e);
   }
 }
+
+// 챌린지 신청 상세 조회 (어드민/유저))
+export const getApplication = async (req, res, next) => {
+  try {
+    const applicationId = Number(req.params.applicationId);
+    const data = await challengeService.getApplicationById(applicationId);
+    const { challenge, ...rest } = data.application;
+    res.json({
+      application: rest,
+      challenge: { ...challenge, participants: challenge.participants.length },
+      prevApplicationId: data.prevApplicationId,
+      nextApplicationId: data.nextApplicationId,
+    });
+  } catch (e) {
+    next(e);
+  }
+};

--- a/src/controllers/challenge.controller.js
+++ b/src/controllers/challenge.controller.js
@@ -170,11 +170,14 @@ export async function updateApplicationStatus(req, res, next) {
 
 export async function getApplications(req, res, next) {
   try {
+    const { userId } = req.user || {}; // 나의 챌린지일 경우
+
     const { totalCount, data } = await challengeService.getApplications({
       page: Number(req.query.page),
       pageSize: Number(req.query.pageSize),
       sort: req.query.sort,
       keyword: req.query.keyword,
+      userId,
     });
     res.json({ totalCount, applications: data });
   } catch (e) {

--- a/src/controllers/user.controller.js
+++ b/src/controllers/user.controller.js
@@ -42,17 +42,3 @@ export const getMyChallenges = async (req, res) => {
     res.status(status).json({ message: error.message || "서버 내부 오류" });
   }
 };
-
-export const getMyApplication = async (req, res) => {
-  const applicationId = Number(req.params.applicationId);
-  try {
-    const data = await userService.getApplication(applicationId);
-    const { challenge, ...rest } = data;
-    res.json({
-      application: rest,
-      challenge: { ...challenge, participants: challenge.participants.length },
-    });
-  } catch (error) {
-    console.error("신청한 챌린지 조회 실패:", error);
-  }
-};

--- a/src/repositories/challenge.repository.js
+++ b/src/repositories/challenge.repository.js
@@ -124,7 +124,6 @@ async function getChallenges(options) {
 
   const where = {};
 
-
   if (category) {
     where.category = category;
   }
@@ -182,7 +181,6 @@ async function getChallenges(options) {
   //모든 챌린지 데이터에서 페이지네이션으로 자르기
   const pagedChallenges = statusFilterdChallenges.slice(skip, skip + take);
 
-
   return {
     totalCount: statusFilterdChallenges.length,
     currentPage: Number(page),
@@ -191,6 +189,7 @@ async function getChallenges(options) {
   };
 }
 
+// 챌린지 신청 목록 조회
 async function findAllApplications(options) {
   const { skip, take, where, orderBy } = options;
 
@@ -215,6 +214,44 @@ async function findAllApplications(options) {
   };
 }
 
+// 챌린지 신청 상세 조회
+export const findApplicationById = async (applicationId) => {
+  const current = await prisma.application.findUnique({
+    where: {
+      id: applicationId,
+    },
+    include: {
+      challenge: {
+        include: {
+          participants: true,
+        },
+      },
+    },
+  });
+
+  if (!current) return null;
+
+  // 이전 신청 챌린지 id 찾기
+  const prev = await prisma.application.findFirst({
+    where: { id: { lt: applicationId } },
+    orderBy: { id: "desc" },
+    select: { id: true },
+  });
+
+  // 다음 신청 챌린지 id 찾기
+  const next = await prisma.application.findFirst({
+    where: { id: { gt: applicationId } },
+    orderBy: { id: "asc" },
+    select: { id: true },
+  });
+
+  return {
+    application: current,
+    prevApplicationId: prev?.id || null,
+    nextApplicationId: next?.id || null,
+  };
+};
+
 export default {
   save,
   getChallenges,
@@ -226,4 +263,5 @@ export default {
   updateApplication,
   deleteChallengeById,
   findChallengeDetailById,
+  findApplicationById,
 };

--- a/src/repositories/user.repository.js
+++ b/src/repositories/user.repository.js
@@ -146,18 +146,3 @@ export const findMyChallengesByStatus = async (
   error.status = 400;
   throw error;
 };
-
-export const findMyApplication = async (applicationId) => {
-  return await prisma.application.findUnique({
-    where: {
-      id: applicationId,
-    },
-    include: {
-      challenge: {
-        include: {
-          participants: true,
-        },
-      },
-    },
-  });
-};

--- a/src/routes/user.route.js
+++ b/src/routes/user.route.js
@@ -1,10 +1,9 @@
 import express from "express";
+import { getMyInfo, getMyChallenges } from "../controllers/user.controller.js";
 import {
-  getMyInfo,
-  getMyChallenges,
-  getMyApplication,
-} from "../controllers/user.controller.js";
-import { getApplications } from "../controllers/challenge.controller.js";
+  getApplication,
+  getApplications,
+} from "../controllers/challenge.controller.js";
 import { verifyAccessToken } from "../middlewares/verifyToken.js";
 
 const userRouter = express.Router();
@@ -15,7 +14,7 @@ userRouter.get("/me/applications", verifyAccessToken, getApplications);
 userRouter.get(
   "/me/applications/:applicationId",
   verifyAccessToken,
-  getMyApplication
+  getApplication
 );
 
 export default userRouter;

--- a/src/routes/user.route.js
+++ b/src/routes/user.route.js
@@ -4,12 +4,14 @@ import {
   getMyChallenges,
   getMyApplication,
 } from "../controllers/user.controller.js";
+import { getApplications } from "../controllers/challenge.controller.js";
 import { verifyAccessToken } from "../middlewares/verifyToken.js";
 
 const userRouter = express.Router();
 
 userRouter.get("/me", verifyAccessToken, getMyInfo);
 userRouter.get("/me/challenges", verifyAccessToken, getMyChallenges);
+userRouter.get("/me/applications", verifyAccessToken, getApplications);
 userRouter.get(
   "/me/applications/:applicationId",
   verifyAccessToken,

--- a/src/services/challenge.service.js
+++ b/src/services/challenge.service.js
@@ -93,9 +93,7 @@ async function getChallenges(options) {
   return challengeRepository.getChallenges(options);
 }
 
-/**
- * 챌린지 신청 관리
- */
+// 챌린지 신청 관리 - 어드민
 async function updateApplicationById(challengeId, data) {
   try {
     const updatedApplication = await challengeRepository.updateApplication(
@@ -137,6 +135,7 @@ async function updateApplicationById(challengeId, data) {
   }
 }
 
+// 챌린지 신청 목록 조회
 async function getApplications({
   page = 1,
   pageSize = 10,
@@ -192,6 +191,15 @@ async function getApplications({
   return challengeRepository.findAllApplications(options);
 }
 
+// 챌린지 신청 상세 조회
+export const getApplicationById = async (applicationId) => {
+  const data = await challengeRepository.findApplicationById(applicationId);
+  if (!data) {
+    throw new BadRequestError(ExceptionMessage.APPLICATION_NOT_FOUND);
+  }
+  return data;
+};
+
 export default {
   create,
   getChallenges,
@@ -202,4 +210,5 @@ export default {
   deleteChallenge,
   getChallengeDetailById,
   updateApplicationById,
+  getApplicationById,
 };

--- a/src/services/challenge.service.js
+++ b/src/services/challenge.service.js
@@ -142,6 +142,7 @@ async function getApplications({
   pageSize = 10,
   sort = "appliedAt_desc",
   keyword,
+  userId,
 }) {
   const offset = (page - 1) * pageSize;
 
@@ -151,6 +152,11 @@ async function getApplications({
     orderBy: {},
     where: {},
   };
+
+  // userId가 있는 경우 authorId 조건 추가
+  if (userId) {
+    options.where.authorId = userId;
+  }
 
   // 필터 조건
   if (["pending", "accepted", "rejected"].includes(sort)) {

--- a/src/services/user.service.js
+++ b/src/services/user.service.js
@@ -1,5 +1,3 @@
-import { ExceptionMessage } from "../exceptions/ExceptionMessage.js";
-import { BadRequestError } from "../exceptions/exceptions.js";
 import * as userRepository from "../repositories/user.repository.js";
 
 export const getMyInfo = async (userId) => {
@@ -27,10 +25,10 @@ export const getMyChallenges = async (
         ],
       }
     : {};
-  
+
   const validStatuses = ["applied", "participated", "completed"];
   const { page = 1, pageSize = 10 } = options;
-    if (!validStatuses.includes(myChallengeStatus)) {
+  if (!validStatuses.includes(myChallengeStatus)) {
     const error = new Error("잘못된 챌린지 상태입니다.");
     error.status = 400;
     throw error;
@@ -56,7 +54,7 @@ export const getMyChallenges = async (
       userId,
       myChallengeStatus,
       keywordFilter,
-      { page, pageSize },
+      { page, pageSize }
     );
 
     return {
@@ -66,12 +64,4 @@ export const getMyChallenges = async (
       pageSize,
     };
   }
-};
-
-export const getApplication = async (applicationId) => {
-  const data = await userRepository.findMyApplication(applicationId);
-  if (!data) {
-    throw new BadRequestError(ExceptionMessage.APPLICATION_NOT_FOUND);
-  }
-  return data;
 };


### PR DESCRIPTION
## 챌린지 신청 목록 조회
- `userId` 있는 경우 where 객체에 추가
- 나의 신청한 챌린지 조회 api 변경
  - 경로 `/users/me/application`로

## 챌린지 신청 상세 조회
- 신청한 챌린지의 이전 id, 다음 id 값 반환 추가
- 기존 user 쪽에 있던 `getMyApplication` 
  - 챌린지 쪽으로 이동(Application 관련 모두 챌린지에서 처리)
  - `getApplication`으로 수정 후 유저, 어드민 모두 사용