### PR TITLE
fix:challenge.repository에 findChallengeDetailById함수에 participants 필드 추가

### DIFF
--- a/src/repositories/challenge.repository.js
+++ b/src/repositories/challenge.repository.js
@@ -55,6 +55,7 @@ const findChallengeDetailById = async (challengeId) => {
           nickname: true,
         },
       },
+      participants: true,
     },
   });
 };


### PR DESCRIPTION
커밋메세지와 동일합니다

현재 챌린지 상세페이지에서 

챌린지 컨테이너 내에 있는 participants 데이터를 제대로 못받아오는 현상을 수정하였습니다. 