### PR TITLE
modify: 쿠키에 role 추가, 어드민 신청 목록 조회 오류 수정

### DIFF
--- a/src/controllers/challenge.controller.js
+++ b/src/controllers/challenge.controller.js
@@ -149,7 +149,7 @@ export const getChallenges = async (req, res, next) => {
 // 챌린지 신청 관리 (승인/거절/삭제)
 export async function updateApplicationStatus(req, res, next) {
   try {
-    const userRole = req.auth?.role;
+    const userRole = req.user?.role;
     if (!userRole === "admin") {
       return res.status(401).json({ message: "관리자만 접근할 수 있습니다. " });
     }
@@ -168,14 +168,15 @@ export async function updateApplicationStatus(req, res, next) {
 // 챌린지 신청 목록 조회 (어드민/유저)
 export async function getApplications(req, res, next) {
   try {
-    const { userId } = req.user || {}; // 나의 챌린지일 경우
+    const userRole = req.user?.role;
+    const userId = userRole === "USER" ? req.user?.userId : undefined;
 
     const { totalCount, data } = await challengeService.getApplications({
       page: Number(req.query.page),
       pageSize: Number(req.query.pageSize),
       sort: req.query.sort,
       keyword: req.query.keyword,
-      userId,
+      userId, // 사용자일 때만
     });
     res.json({ totalCount, applications: data });
   } catch (e) {

--- a/src/middlewares/verifyToken.js
+++ b/src/middlewares/verifyToken.js
@@ -9,7 +9,7 @@ export const verifyAccessToken = (req, res, next) => {
 
   try {
     const decoded = jwt.verify(token, process.env.JWT_SECRET_KEY);
-    req.user = decoded; // { userId, email, nickname }
+    req.user = decoded; // { userId, email, nickname, role }
     next();
   } catch (err) {
     return res

--- a/src/repositories/auth.repository.js
+++ b/src/repositories/auth.repository.js
@@ -6,6 +6,7 @@ async function saveUser(user, hashedPassword) {
       email: user.email,
       nickname: user.nickname,
       hashedPassword: hashedPassword,
+      role: "USER",
     },
   });
 }

--- a/src/services/auth.service.js
+++ b/src/services/auth.service.js
@@ -41,6 +41,7 @@ async function createUser(user) {
       id: createdUser.id,
       email: createdUser.email,
       nickname: createdUser.nickname,
+      role: createdUser.role,
     },
   };
 }

--- a/src/utils/accessToken.utils.js
+++ b/src/utils/accessToken.utils.js
@@ -6,6 +6,7 @@ export function generateAccessToken(user) {
     userId: user.id,
     email: user.email,
     nickname: user.nickname,
+    role: user.role,
   };
 
   const accessSecret = `${process.env.JWT_SECRET_KEY}`;
@@ -27,6 +28,7 @@ export function generateRefreshToken(user) {
     userId: user.id,
     email: user.email,
     nickname: user.nickname,
+    role: user.role,
   };
 
   const refreshSecret = `${process.env.JWT_REFRESH_SECRET_KEY}`;


### PR DESCRIPTION
## 토큰 Payload에 유저 role 추가
<img width="1207" alt="image" src="https://github.com/user-attachments/assets/5398728b-1402-400e-a04b-6364e1ed29d1" />

## 챌린지 신청목록 조회 API 
### 오류
- 기존 유저와 같이 쓰기 위해 userId를 추가했는데 관리자인지 확인이 불가하여 관리자도 관리자 id의 챌린지만 보임
### 수정 
- accessToken에 추가한 role로 관리자를 판별하여 관리자일땐 전체 목록 조회, 유저일땐 본인이 신청한 챌린지만 조회되도록 수정