### PR TITLE
fix: 챌린지 목록 조회 시 승인된 챌린지만 볼 수 있도록 수정

### DIFF
--- a/src/repositories/challenge.repository.js
+++ b/src/repositories/challenge.repository.js
@@ -180,7 +180,12 @@ async function getChallenges(options) {
 
   //데이터의 총 갯수(챌린지 상태는 제외되어있음)
   let allChallenges = await prisma.challenge.findMany({
-    where,
+    where: {
+      ...where,
+      application: {
+        adminStatus: "ACCEPTED", // ✅ 여기가 핵심!
+      },
+    },
     include: {
       participants: true,
       application: {


### PR DESCRIPTION
- 기존 코드
챌린지 목록 페이지 조회 시 관리자의 승인을 받지 못한 챌린지들 (거절, 삭제, 대기중)도 조회가 가능함

- 수정된 코드
챌린지 목록 페이지 조회 시 관리자의 승인을 받은 챌린지만(승인) 조회가 가능하게 함
쿼리 스트링에 adminStatus="ACCEPTED"를 추가하여 데이터를 불러올 수 있도록 함