### PR TITLE
feat: 챌린지수정하기에 adminValidator 미들웨어 추가(유저수정불가로직)

### DIFF
--- a/http/challenge.http
+++ b/http/challenge.http
@@ -1,5 +1,4 @@
-@accessToken=
-
+@accessToken=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOiJjbWIwYWlzeXAwMDAwY2NveWFhem1tbzllIiwiZW1haWwiOiJna3NrdGwxMjNAbmF2ZXIuY29tIiwibmlja25hbWUiOiLrgpjripTslbzrqYvsp4TquIjrtpXslrQiLCJyb2xlIjoiVVNFUiIsImlhdCI6MTc0ODY4NjcyMSwiZXhwIjoxNzQ4Njg3NjIxfQ.6m1o2jSwmKCQX93JtSBxVg_Dz8SoGLs9DOj3WFAX4Ic
 ### 챌린지 쿼리 조회
 GET http://localhost:8080/challenges?page=3&pageSize=4&category=&docType=&keyword=ㅊㄹㅈ&status=
 

--- a/src/app.js
+++ b/src/app.js
@@ -13,6 +13,7 @@ import "./middlewares/passport/passport.js";
 import adminRouter from "./routes/admin.route.js";
 import { startDeadlineScheduler } from "./utils/scheduler.js";
 import { adminValidator } from "./middlewares/validator.js";
+import { verifyAccessToken } from "./middlewares/verifyToken.js";
 
 const app = express();
 const PORT = process.env.PORT;
@@ -53,7 +54,7 @@ app.use("/users", userRouter);
 app.use("/challenges", challengeRouter);
 app.use("/works", workRouter);
 app.use("/notifications", notificationRouter);
-app.use("/admin", adminValidator, adminRouter);
+app.use("/admin", verifyAccessToken, adminValidator, adminRouter);
 app.use(errorHandler);
 
 startDeadlineScheduler();

--- a/src/app.js
+++ b/src/app.js
@@ -12,6 +12,7 @@ import passport from "passport";
 import "./middlewares/passport/passport.js";
 import adminRouter from "./routes/admin.route.js";
 import { startDeadlineScheduler } from "./utils/scheduler.js";
+import { adminValidator } from "./middlewares/validator.js";
 
 const app = express();
 const PORT = process.env.PORT;
@@ -52,7 +53,7 @@ app.use("/users", userRouter);
 app.use("/challenges", challengeRouter);
 app.use("/works", workRouter);
 app.use("/notifications", notificationRouter);
-app.use("/admin", adminRouter);
+app.use("/admin", adminValidator, adminRouter);
 app.use(errorHandler);
 
 startDeadlineScheduler();

--- a/src/routes/admin.route.js
+++ b/src/routes/admin.route.js
@@ -1,7 +1,6 @@
 import express from "express";
 import { verifyAccessToken } from "../middlewares/verifyToken.js";
 import { softDeleteWork } from "../controllers/admin.controller.js";
-import { adminValidator } from "../middlewares/validator.js";
 import {
   getApplications,
   updateApplicationStatus,
@@ -9,16 +8,10 @@ import {
 
 const adminRouter = express.Router({ mergeParams: true });
 
-adminRouter.get(
-  "/applications",
-  verifyAccessToken,
-  adminValidator,
-  getApplications
-);
+adminRouter.get("/applications", verifyAccessToken, getApplications);
 adminRouter.patch(
   "/challenges/:challengeId",
   verifyAccessToken,
-  adminValidator,
   updateApplicationStatus
 );
 adminRouter.patch("/works/:workId", verifyAccessToken, softDeleteWork);

--- a/src/routes/admin.route.js
+++ b/src/routes/admin.route.js
@@ -8,12 +8,8 @@ import {
 
 const adminRouter = express.Router({ mergeParams: true });
 
-adminRouter.get("/applications", verifyAccessToken, getApplications);
-adminRouter.patch(
-  "/challenges/:challengeId",
-  verifyAccessToken,
-  updateApplicationStatus
-);
-adminRouter.patch("/works/:workId", verifyAccessToken, softDeleteWork);
+adminRouter.get("/applications", getApplications);
+adminRouter.patch("/challenges/:challengeId", updateApplicationStatus);
+adminRouter.patch("/works/:workId", softDeleteWork);
 
 export default adminRouter;

--- a/src/routes/challenge.route.js
+++ b/src/routes/challenge.route.js
@@ -8,6 +8,7 @@ import {
 } from "../controllers/challenge.controller.js";
 import { verifyAccessToken } from "../middlewares/verifyToken.js";
 import workRouter from "./work.route.js";
+import { adminValidator } from "../middlewares/validator.js";
 
 const challengeRouter = express.Router();
 
@@ -21,8 +22,12 @@ challengeRouter.post("/", verifyAccessToken, createChallenge);
 challengeRouter.get("/:challengeId", getChallengeById);
 
 // 챌린지 수정
-
-challengeRouter.put("/:challengeId", verifyAccessToken, updateChallenge);
+challengeRouter.put(
+  "/:challengeId",
+  verifyAccessToken,
+  adminValidator,
+  updateChallenge
+);
 
 // 챌린지 삭제
 challengeRouter.delete("/:challengeId", verifyAccessToken, deleteChallenge);


### PR DESCRIPTION
챌린지수정하기에 adminValidator 미들웨어 추가(유저수정불가로직)을 추가했습니다.

그리고 adminRouter에 매 함수마다 중복되는 adminValidator 미들웨어를 app.js 에서 한번에 어드민여부 검증하도록 리팩터링하였습니다.

---


![image](https://github.com/user-attachments/assets/92404d66-4424-4c50-93fb-734dca82848a)

![image](https://github.com/user-attachments/assets/d86e5e22-d480-4887-b536-5532a4bff7dd)
